### PR TITLE
Purge relative_reference_index from repo

### DIFF
--- a/big-blue.cfg
+++ b/big-blue.cfg
@@ -357,7 +357,6 @@ fade_start: 0.6
 fade_end: 10.0
 probe_count: 5,5
 algorithm: bicubic
-relative_reference_index: 12
 
 [firmware_retraction]
 retract_length: 0.5

--- a/bumblebee.cfg
+++ b/bumblebee.cfg
@@ -388,7 +388,6 @@ fade_start: 0.6
 fade_end: 10.0
 probe_count: 5,5
 algorithm: bicubic
-relative_reference_index: 12
 
 ########################################
 # EXP1 / EXP2 (display) pins

--- a/hardware/v1/v24r2_300.cfg
+++ b/hardware/v1/v24r2_300.cfg
@@ -30,4 +30,3 @@ fade_start: 0.6
 fade_end: 10.0
 probe_count: 5,5
 algorithm: bicubic
-relative_reference_index: 12

--- a/xp22.cfg
+++ b/xp22.cfg
@@ -351,7 +351,6 @@ fade_start: 0.6
 fade_end: 10.0
 probe_count: 7,7
 algorithm: bicubic
-relative_reference_index: 24
 
 ########################################
 # EXP1 / EXP2 (display) pins

--- a/xp23.cfg
+++ b/xp23.cfg
@@ -347,7 +347,6 @@ fade_start: 0.6
 fade_end: 10.0
 probe_count: 7,7
 algorithm: bicubic
-relative_reference_index: 24
 
 ########################################
 # EXP1 / EXP2 (display) pins


### PR DESCRIPTION
No longer valid in newer versions of klipper - let's just remove it.